### PR TITLE
Added en_US-UTF-8 as the default locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,13 @@ ENV ANDROID_HOME /opt/android-sdk
 ENV PATH ${PATH}:${GRADLE_HOME}/bin:${KOTLIN_HOME}/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools/bin
 ENV _JAVA_OPTIONS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 
+# Sets UTF-8 english as the default locale -- necessary for some Java processor in Android (jetifier for example)
+RUN apt-get install -y locales
+RUN locale-gen en_US.UTF-8
+
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
 # accept the license agreements of the SDK components
 ADD license_accepter.sh /opt/
 RUN chmod 771 /opt/license_accepter.sh \


### PR DESCRIPTION
Using androidx in my project, I ran into the same issue than this guy: https://issuetracker.google.com/issues/113880420

```
[03:13:25]: ▸ > Task :app:kaptGenerateStubsStagingReleaseKotlin FAILED
--
  | [03:13:25]: ▸ FAILURE: Build failed with an exception.
  | [03:13:25]: ▸ * What went wrong:
  | [03:13:25]: ▸ Execution failed for task ':app:kaptGenerateStubsStagingReleaseKotlin'.
  | [03:13:25]: ▸ > Could not resolve all files for configuration ':app:kapt'.
  | [03:13:25]: ▸ > Failed to transform file 'kotlin-compiler-embeddable-1.2.71.jar' to match attributes {artifactType=processed-jar} using transform JetifyTransform
  | [03:13:25]: ▸ > Failed to transform '/root/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler-embeddable/1.2.71/a79f934bfbc1c7e16638da3474feab351735f1c0/kotlin-compiler-embeddable-1.2.71.jar' using Jetifier. Reason: Malformed input or input contains unmappable characters: javaslang/?.class. (Run with --stacktrace for more details.) To disable Jetifier, set android.enableJetifier=false in your gradle.properties file.
```

It was triggered by the Ubuntu locale that was not set properly in the Docker image.

That article helped me find an elegant solution:
https://www.roadsi.de/blog/locales-on-ubuntu-in-docker/

I've already published a 1.2.2 version of the image to be able to test and it indeed fixed the build issue.